### PR TITLE
Fix reflink matching links

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { table } from './rules/table.js';
 import { fence } from './rules/fence.js';
 import { codeBlock } from './rules/codeBlock.js';
 import { image } from './rules/image.js';
+import { reflink } from './rules/reflink.js';
 import SimpleMarkdown from 'simple-markdown';
 
 export interface Options {
@@ -57,7 +58,8 @@ const rules = Object.assign({}, SimpleMarkdown.defaultRules, {
 	table,
 	fence,
 	codeBlock,
-	image
+	image,
+	reflink
 });
 
 const parser = SimpleMarkdown.parserFor(rules);

--- a/src/rules/reflink.ts
+++ b/src/rules/reflink.ts
@@ -1,0 +1,19 @@
+import SimpleMarkdown from 'simple-markdown';
+import { SimpleMarkdownRule } from './ruleType.js';
+
+// Modifies original reflink rule to
+export const reflink: SimpleMarkdownRule = Object.assign({}, SimpleMarkdown.defaultRules.reflink, {
+	match: function (source, state, prevCapture) {
+		const LINK_INSIDE = '(?:\\[[^\\]]*\\]|[^\\[\\]]|\\](?=[^\\[]*\\]))*';
+		return SimpleMarkdown.inlineRegex(
+			new RegExp(
+				// The first [part] of the link
+				'^\\[(' +
+					LINK_INSIDE +
+					')\\]' +
+					// The [ref] target of the link
+					'\\s*\\[([^\\]]*)\\](?!(.*))'
+			)
+		)(source, state, prevCapture);
+	} satisfies SimpleMarkdown.MatchFunction
+});

--- a/src/rules/reflink.ts
+++ b/src/rules/reflink.ts
@@ -1,7 +1,8 @@
 import SimpleMarkdown from 'simple-markdown';
 import { SimpleMarkdownRule } from './ruleType.js';
 
-// Modifies original reflink rule to
+// Modifies original reflink rule to not match when a link is the second bracket
+// like [] []()
 export const reflink: SimpleMarkdownRule = Object.assign({}, SimpleMarkdown.defaultRules.reflink, {
 	match: function (source, state, prevCapture) {
 		const LINK_INSIDE = '(?:\\[[^\\]]*\\]|[^\\[\\]]|\\](?=[^\\[]*\\]))*';

--- a/tests/reflink.test.ts
+++ b/tests/reflink.test.ts
@@ -1,0 +1,12 @@
+import { describe, test, expect } from 'vitest';
+import { converter } from '../src/index.js';
+
+describe('reflink', () => {
+	test('reflink not matching when link after', () => {
+		const text = `[L] [DiddyKong](#U-DiddyKong) Tweek`;
+		const htmlResult = converter(text);
+		expect(htmlResult).toBe(
+			'<p>[L] <a href="#U-DiddyKong" rel="noopener nofollow ugc">DiddyKong</a> Tweek</p>'
+		);
+	});
+});


### PR DESCRIPTION
Reflinks can match things like `[text]label]`, but it would also match things like `[L] [DiddyKong](#U-DiddyKong)` when it is not supposed to, since the second part is a normal link.

This PR prevents reflink from matching the latter by adding a negative lookahead for `()` after `[]` in the second square brackets.