### PR TITLE
Add `https://` to `www.` links

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "reddit-md-to-html",
-	"version": "0.1.18",
+	"version": "0.1.19",
 	"description": "A markdown to html converter for Reddit-flavored markdown",
 	"repository": {
 		"type": "git",

--- a/src/rules/link.ts
+++ b/src/rules/link.ts
@@ -5,6 +5,7 @@ import { SimpleMarkdownRule } from './ruleType.js';
 // that the text has already been ran through the link rule
 // Used to prevent double <a> tags
 // Also modifies href tag output to ignore backslashes
+// Also outputs prepends https:// to of www. links
 export const link: SimpleMarkdownRule = Object.assign({}, SimpleMarkdown.defaultRules.link, {
 	parse: function (capture, parse, state) {
 		state.link = true;
@@ -18,7 +19,9 @@ export const link: SimpleMarkdownRule = Object.assign({}, SimpleMarkdown.default
 	} satisfies SimpleMarkdown.ParseFunction,
 	html: function (node, output, state) {
 		const attributes = {
-			href: SimpleMarkdown.sanitizeUrl(node.target)?.replace(/\\/g, ''),
+			href: SimpleMarkdown.sanitizeUrl(node.target)
+				?.replace(/\\/g, '')
+				.replace(/^www\./, 'https://www.'),
 			title: node.title,
 			rel: 'noopener nofollow ugc'
 		};

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -124,7 +124,7 @@ describe('url', () => {
 	test('url starting with www.', () => {
 		const htmlResult = converter('Visit www.google.ca for more info');
 		expect(htmlResult).toBe(
-			'<p>Visit <a href="www.google.ca" rel="noopener nofollow ugc">www.google.ca</a> for more info</p>'
+			'<p>Visit <a href="https://www.google.ca" rel="noopener nofollow ugc">www.google.ca</a> for more info</p>'
 		);
 	});
 


### PR DESCRIPTION
Fixes `www.` not having `https://` in the href part of an `a` tag. 

Without a `https://`, the link would be treated as relative.