### PR TITLE
Fix text rule splitting text into characters too extremely

### DIFF
--- a/src/rules/text.ts
+++ b/src/rules/text.ts
@@ -2,14 +2,15 @@ import SimpleMarkdown from 'simple-markdown';
 import { SimpleMarkdownRule } from './ruleType.js';
 import { urlRegex } from './url.js';
 
-// Modifies original text rule to not output backslashes from urls
+// Modifies original text rule html to not output backslashes from urls
 // Also modifies the match function to not only capture text before `/`
 // This is used for matching redditlinks like `r/programing` so the `r`
 // is not captured before the rest of the link
-// Modifies match function to not capture text around www.
+// Modifies match function to not capture a number before a . (e.g. 123.) for list markers
+// Modifies match function to not capture www.
 export const text: SimpleMarkdownRule = Object.assign({}, SimpleMarkdown.defaultRules.text, {
 	match: SimpleMarkdown.anyScopeRegex(
-		/^[\s\S]+?(?=[^0-9A-Za-z\s\u00c0-\uffff]|\n\n| {2,}\n|\w+(?::|\/|www.)|\S|$)/
+		/^[\s\S]+?(?=[^0-9A-Za-z\s\u00c0-\uffff]|\n\n| {2,}\n|\w+:\S|r\/|\d+\.|www\.|$)/
 	) satisfies SimpleMarkdown.MatchFunction,
 	html: function (node) {
 		if (node.content.match(urlRegex)) {

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -121,6 +121,13 @@ describe('url', () => {
 		);
 	});
 
+	test('url with www. link only', () => {
+		const htmlResult = converter('www.google.ca');
+		expect(htmlResult).toBe(
+			'<p><a href="https://www.google.ca" rel="noopener nofollow ugc">www.google.ca</a></p>'
+		);
+	});
+
 	test('url starting with www.', () => {
 		const htmlResult = converter('Visit www.google.ca for more info');
 		expect(htmlResult).toBe(

--- a/tests/textsplit.test.ts
+++ b/tests/textsplit.test.ts
@@ -1,0 +1,21 @@
+import { describe, test, expect } from 'vitest';
+import { parse } from '../src/index.js';
+
+describe('text splitting', () => {
+	test('text splits', () => {
+		const text = '>! Spoiler text here !<';
+		const expectedTree = [
+			{
+				content: [
+					{
+						content: [{ content: 'Spoiler text here', type: 'text' }],
+						type: 'spoiler'
+					}
+				],
+				type: 'paragraph'
+			}
+		];
+
+		expect(parse(text)).toStrictEqual(expectedTree);
+	});
+});


### PR DESCRIPTION
Previously, we modified the match regex for the text rule to prevent it from matching too many characters.  
However, this change caused it to match too heavily, splitting words at each character.

e.g.
```
content: [
    { content: 't', type: 'text' },
    { content: 'h', type: 'text' },
    { content: 'i', type: 'text' },
    { content: 's ', type: 'text' }
]
```

This PR fixes the regex to not cause each word to split at each character.  
After this fix, the resulting tree will be 

```
content: 
    [{ content: 'this, type: 'text' }
]
```