### PR TITLE
Fix list marker matching as nested list when inline regex in front of list marker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "reddit-md-to-html",
-	"version": "0.1.21",
+	"version": "0.1.22",
 	"description": "A markdown to html converter for Reddit-flavored markdown",
 	"repository": {
 		"type": "git",

--- a/tests/unorderedlist.test.ts
+++ b/tests/unorderedlist.test.ts
@@ -14,6 +14,15 @@ describe('unorderedlist', () => {
 			'<ul><li>this</li><li>is</li><li>a great</li><li>list</li><li>with</li><li>text</li></ul>'
 		);
 	});
+
+	test('unorderedlist with another list marker inside a list item and bold', () => {
+		const text = `- **this is a list with a ** - dash in it
+- **some more text** * yeah more text`;
+		const htmlResult = converter(text);
+		expect(htmlResult).toBe(
+			'<ul><li><strong>this is a list with a </strong> - dash in it</li><li><strong>some more text</strong> * yeah more text</li></ul>'
+		);
+	});
 });
 
 describe('nested unorderedlists', () => {


### PR DESCRIPTION
An issue would occur when matching a list marker and there is a inline match and a space in front of the list marker.

e.g.
```
* **This** - is text
* Another list line
```
would match the `- is text` since the `**This**` would get matched, then the space in front of the `- text` would be the next prevCapture, leading the match to think it is the start of a nested list item.

This PR fixes this issue by setting a flag when the capture starts with a space and the previous capture is not empty, so we know we can skip the next match. 