### PR TITLE
Fix heading with spaces in front

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "reddit-md-to-html",
-	"version": "0.1.36",
+	"version": "0.1.37",
 	"description": "A markdown to html converter for Reddit-flavored markdown",
 	"repository": {
 		"type": "git",

--- a/src/rules/heading.ts
+++ b/src/rules/heading.ts
@@ -3,5 +3,5 @@ import { SimpleMarkdownRule } from './ruleType.js';
 
 // Modifies original heading rule to support a new block on the next line
 export const heading: SimpleMarkdownRule = Object.assign({}, SimpleMarkdown.defaultRules.heading, {
-	match: SimpleMarkdown.blockRegex(/^ *(#{1,6}) *([^\n]+?) *#* *(?:\n *)*\n/)
+	match: SimpleMarkdown.blockRegex(/^ {0,3}(#{1,6}) *([^\n]+?) *#* *(?:\n *)*\n/)
 });

--- a/tests/heading.test.ts
+++ b/tests/heading.test.ts
@@ -7,6 +7,41 @@ describe('heading', () => {
 
 		expect(htmlResult).toBe('<h1>heading</h1>');
 	});
+
+	test('heading with <4 spaces in front', () => {
+		const htmlResult = converter('   #heading');
+
+		expect(htmlResult).toBe('<h1>heading</h1>');
+	});
+
+	test('heading does not convert when there are >3 spaces in front', () => {
+		const text = `For example:
+
+    #[derive(thiserror::Error, Debug)]
+    pub enum Error {
+        #[error(transparent)]
+        Contract(#[from] contract::Error),
+        #[error(transparent)]
+        Events(#[from] events::Error),
+        #[error(transparent)]
+        Lab(#[from] lab::Error),
+        #[error(transparent)]
+        Config(#[from] config::Error),
+    }`;
+
+		const htmlResult = converter(text);
+		expect(htmlResult).toBe(`<p>For example:</p><pre><code>#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Contract(#[from] contract::Error),
+    #[error(transparent)]
+    Events(#[from] events::Error),
+    #[error(transparent)]
+    Lab(#[from] lab::Error),
+    #[error(transparent)]
+    Config(#[from] config::Error),
+}</code></pre>`);
+	});
 });
 
 describe('lheading', () => {


### PR DESCRIPTION
Now correctly converts headings with 0-3 spaces in front to heading tags.