### PR TITLE
Fix list skipping when space at the end of line

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "reddit-md-to-html",
-	"version": "0.1.49",
+	"version": "0.1.50",
 	"description": "A markdown to html converter for Reddit-flavored markdown",
 	"repository": {
 		"type": "git",

--- a/src/rules/list.ts
+++ b/src/rules/list.ts
@@ -31,8 +31,10 @@ export const list: SimpleMarkdownRule = Object.assign({}, SimpleMarkdown.default
 		// since prevCaptureStr will now be a ` `.
 		// To prevent this, we simply check if the start of the source is a space and the previous capture was not empty, and set a flag if it so
 		if (state.skipNextList) {
-			state.skipNextList = false;
-			return null;
+			if (!isStartOfLineCapture || (isStartOfLineCapture && isStartOfLineCapture[0] !== '\n')) {
+				state.skipNextList = false;
+				return null;
+			}
 		}
 		if (source[0] === ' ' && !isStartOfLineCapture) {
 			state.skipNextList = true;

--- a/tests/unorderedlist.test.ts
+++ b/tests/unorderedlist.test.ts
@@ -63,6 +63,21 @@ describe('unorderedlist', () => {
 			'<ul><li><p>Playin Stage</p><ul><li>8 teams participate</li><li>Teams are drawn into two double elimination brackets</li><li>Bracket matches are best of three</li><li>LCQ match is best of five</li><li>Winners of each group and the winner of the LCQ match between the lower bracket winners advance to Stage 2</li></ul></li><li><p>Bracket Stage</p><ul><li>8 teams participate</li><li>Double elimination bracket</li><li>All matches are Best of 5</li><li>Teams are drawn into the bracket with teams from tier 1 and 2 playing teams from tier 3.</li><li>Teams from tier 1 are placed on the opposite side of the bracket.</li><li>Teams from the same region can&#x27;t be draw in the first match of the bracket stage.</li></ul></li></ul><hr><h3>Tiers</h3>'
 		);
 	});
+
+	test('unordered list with text before and a space at the end of that text', () => {
+		const text = `# NEW BANNERS
+
+During this event, there will be **TWO DIFFERENT BANNERS.** 
+
+* One of them will include all ships of the collab, but only the **new ones will have a higher chance of dropping**
+* One of rhem will consist exclusively of characters from the original run
+
+# New skins`;
+		const htmlResult = converter(text);
+		expect(htmlResult).toBe(
+			'<h1>NEW BANNERS</h1><p>During this event, there will be <strong>TWO DIFFERENT BANNERS.</strong> </p><ul><li>One of them will include all ships of the collab, but only the <strong>new ones will have a higher chance of dropping</strong></li><li>One of rhem will consist exclusively of characters from the original run</li></ul><h1>New skins</h1>'
+		);
+	});
 });
 
 describe('nested unorderedlists', () => {


### PR DESCRIPTION
The list match will skip if there is a space before the list marker. However, this will also skip when the list marker is the start of a  new line. To fix this, we simply add a check if the last capture was a new line character and proceed with the match.