### PR TITLE
Fix superscript matching parentheses in `( )` too greedily

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "reddit-md-to-html",
-	"version": "0.1.51",
+	"version": "0.1.52",
 	"description": "A markdown to html converter for Reddit-flavored markdown",
 	"repository": {
 		"type": "git",

--- a/src/rules/superscript.ts
+++ b/src/rules/superscript.ts
@@ -1,19 +1,66 @@
 import SimpleMarkdown from 'simple-markdown';
 import { SimpleMarkdownRule } from './ruleType.js';
 
+function backtrackParentheses(fullMatch: string, capture: string) {
+	if (fullMatch.length > 2) {
+		if (fullMatch[1] !== '(' || fullMatch[fullMatch.length - 1] !== ')') {
+			return null;
+		}
+	}
+
+	if (fullMatch.length < 4) {
+		// ^ ( ) and any character = 4 characters
+		return null;
+	}
+
+	let count = 2;
+	let countLeftParenthesis = 1;
+
+	for (let i = 0; i < capture.length; i++) {
+		if (capture[i] === '(') {
+			countLeftParenthesis++;
+		} else if (capture[i] === ')') {
+			countLeftParenthesis--;
+		}
+
+		if (countLeftParenthesis === 0) {
+			break;
+		}
+		count++;
+	}
+
+	const newCapture = fullMatch.slice(2, count);
+	return [fullMatch.slice(0, count + 1), newCapture];
+}
+
 export const superscript: SimpleMarkdownRule = {
 	order: SimpleMarkdown.defaultRules.blockQuote.order - 0.5,
 	match: function (source, state, prevCapture) {
-		// If the superscript is in a table, we need to use a modified verision of the
-		// match regex to stop matching at `|` (table separator)
-		if (state.isTable) {
-			return SimpleMarkdown.inlineRegex(/^\^+(?:\((.+)\)|([^\s^|]+))/)(source, state, prevCapture);
-		}
-		return SimpleMarkdown.inlineRegex(/^\^+(?:(\[[^\]]*\]\([^ ]*\))|\((.+)\)|([^\s^]+))/)(
+		let match = SimpleMarkdown.inlineRegex(/^\^+(?:(\[[^\]]*\]\([^ ]*\))|\((.+)\)|([^\s^]+))/)(
 			source,
 			state,
 			prevCapture
 		);
+
+		// If the superscript is in a table, we need to use a modified verision of the
+		// match regex to stop matching at `|` (table separator)
+		if (state.isTable) {
+			match = SimpleMarkdown.inlineRegex(/^\^+(?:\((.+)\)|([^\s^|]+))/)(source, state, prevCapture);
+		}
+
+		if (!match) {
+			return null;
+		}
+
+		// The regex cannot detect if the parentheses are unbalanced, so we may need to backtrack
+		// if the regex has matched too far
+		const backtrackMatch = backtrackParentheses(match[0], match[1] ?? match[2] ?? match[3]);
+
+		if (backtrackMatch) {
+			return backtrackMatch;
+		}
+
+		return match;
 	},
 	parse: function (capture, parse, state) {
 		return {

--- a/tests/superscript.test.ts
+++ b/tests/superscript.test.ts
@@ -59,6 +59,14 @@ describe('superscript', () => {
 		);
 	});
 
+	test('superscript with ) closing immediately', () => {
+		const text = `you have a 3rd party YouTube ^(*or Reddit) client installed that you have set as the Default for YouTube links, this 3rd party client somehow changes the UI so much that you cannot see who (what Channel) the creator is. If that's the case, open the link in your browser of choice, or even pasting the URL into the Search bar in the YouTube app will work. `;
+		const htmlResult = converter(text);
+		expect(htmlResult).toBe(
+			'<p>you have a 3rd party YouTube <sup>*or Reddit</sup> client installed that you have set as the Default for YouTube links, this 3rd party client somehow changes the UI so much that you cannot see who (what Channel) the creator is. If that&#x27;s the case, open the link in your browser of choice, or even pasting the URL into the Search bar in the YouTube app will work. </p>'
+		);
+	});
+
 	// Inconsistent with both new and old reddit
 	test.fails('superscript with em', () => {
 		const htmlResult = converter('^(superscript-_+_++_+_++++___+_+__******#**!#@$#${}[])');


### PR DESCRIPTION
Fixes superscript matching parentheses in `( )` too greedily by finding balanced parentheses.