### PR TITLE
Fix reflink output when def is not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "reddit-md-to-html",
-	"version": "0.1.60",
+	"version": "0.1.61",
 	"description": "A markdown to html converter for Reddit-flavored markdown",
 	"repository": {
 		"type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { codeBlock } from './rules/codeBlock.js';
 import { image, redditImage } from './rules/image.js';
 import { reflink } from './rules/reflink.js';
 import { strong } from './rules/strong.js';
+import { def } from './rules/def.js';
 import { Options } from './options.js';
 import SimpleMarkdown from 'simple-markdown';
 
@@ -52,6 +53,7 @@ const rules = Object.assign({}, SimpleMarkdown.defaultRules, {
 	image,
 	redditImage,
 	reflink,
+	def,
 	strong
 });
 

--- a/src/rules/def.ts
+++ b/src/rules/def.ts
@@ -1,0 +1,39 @@
+import SimpleMarkdown from 'simple-markdown';
+import { SimpleMarkdownRule } from './ruleType.js';
+
+// Modifies original def rule to also set a `found` flag on the ref node
+// This is used to outputting the reflink html:
+// If we found the def, we output a link
+// else, we simply output the original text instead
+export const def: SimpleMarkdownRule = Object.assign({}, SimpleMarkdown.defaultRules.def, {
+	parse: function (capture, _parse, state) {
+		const def = capture[1].replace(/\s+/g, ' ').toLowerCase();
+		const target = capture[2];
+		const title = capture[3];
+
+		if (state._refs && state._refs[def]) {
+			state._refs[def].forEach(function (
+				refNode: SimpleMarkdown.RefNode & {
+					original: SimpleMarkdown.SingleASTNode[];
+					found: boolean;
+				}
+			) {
+				refNode.target = target;
+				refNode.title = title;
+				refNode.found = true;
+			});
+		}
+
+		state._defs = state._defs || {};
+		state._defs[def] = {
+			target: target,
+			title: title
+		};
+
+		return {
+			def: def,
+			target: target,
+			title: title
+		};
+	} satisfies SimpleMarkdown.ParseFunction
+});

--- a/src/rules/reflink.ts
+++ b/src/rules/reflink.ts
@@ -1,10 +1,64 @@
 import SimpleMarkdown from 'simple-markdown';
 import { SimpleMarkdownRule } from './ruleType.js';
 
+// Copy of SimepleMarkdown.parseRef function since the function is not exported
+const parseRef = function (
+	capture: SimpleMarkdown.Capture,
+	state: SimpleMarkdown.State,
+	refNode: SimpleMarkdown.RefNode & { original: SimpleMarkdown.SingleASTNode[]; found: boolean }
+): SimpleMarkdown.RefNode {
+	const ref = (capture[2] || capture[1]).replace(/\s+/g, ' ').toLowerCase();
+
+	if (state._defs && state._defs[ref]) {
+		const def = state._defs[ref];
+		refNode.target = def.target;
+		refNode.title = def.title;
+	}
+
+	state._refs = state._refs || {};
+	state._refs[ref] = state._refs[ref] || [];
+	state._refs[ref].push(refNode);
+
+	return refNode;
+};
+
 // Modifies original reflink rule to not match when a link is the second bracket
 // like [] []()
+// Also modifies the reflink rule to output the original text when a [def]: is not found for the reflink
 export const reflink: SimpleMarkdownRule = Object.assign({}, SimpleMarkdown.defaultRules.reflink, {
-	match: SimpleMarkdown.inlineRegex(
-		/^\[((?:\[[^\]]*\]|[^[\]]|\](?=[^[]*\]))*)\]\s*\[([^\]]*)\](?!\()/
-	) satisfies SimpleMarkdown.MatchFunction
+	match: function (source, state, prevCapture) {
+		if (state.isReflink) {
+			return null;
+		}
+		return SimpleMarkdown.inlineRegex(
+			/^\[((?:\[[^\]]*\]|[^[\]]|\](?=[^[]*\]))*)\]\s*\[([^\]]*)\](?!\()/
+		)(source, state, prevCapture);
+	} satisfies SimpleMarkdown.MatchFunction,
+	parse: function (capture, parse, state) {
+		state.isReflink = true;
+		const parsedRef = parseRef(capture, state, {
+			type: 'reflink',
+			content: parse(capture[1], state),
+			original: parse(capture[0], state),
+			found: false
+		});
+		state.isReflink = false;
+		return parsedRef;
+	} satisfies SimpleMarkdown.ParseFunction,
+	html: function (node, output, state) {
+		if (!node.found) {
+			return output(node.original, state);
+		}
+
+		const attributes = {
+			href: SimpleMarkdown.sanitizeUrl(node.target)
+				?.replace(/\\/g, '')
+				.replace(/^www\./, 'https://www.'),
+			title: node.title,
+			rel: 'noopener nofollow ugc',
+			target: node.addTargetBlank ? '_blank' : null
+		};
+
+		return SimpleMarkdown.htmlTag('a', output(node.content, state), attributes);
+	} satisfies SimpleMarkdown.HtmlNodeOutput
 });

--- a/tests/reflink.test.ts
+++ b/tests/reflink.test.ts
@@ -23,6 +23,15 @@ it is all within yourself, in your [way of thinking][wot].
 it is all within yourself, in your <a href="https://www.reddit.com/r/ChangeMyView/" rel="noopener nofollow ugc">way of thinking</a>.</p>`);
 	});
 
+	test('reflink does not convert when [link]: is not found ', () => {
+		const text =
+			"I miss bbcode formatting. Something simple and easy to remember for formatting that you can't screw up or accidentally cause. To quote was simply [quote] [/quote] spoiler is [spoiler] [/spoiler]. It was easy to understand and use. No dumb symbol use where you may accidentally invoke or whatever.";
+		const htmlResult = converter(text);
+		expect(htmlResult).toBe(
+			'<p>I miss bbcode formatting. Something simple and easy to remember for formatting that you can&#x27;t screw up or accidentally cause. To quote was simply [quote] [/quote] spoiler is [spoiler] [/spoiler]. It was easy to understand and use. No dumb symbol use where you may accidentally invoke or whatever.</p>'
+		);
+	});
+
 	test('does not convert []', () => {
 		const text = `[Very little]`;
 		const htmlResult = converter(text);


### PR DESCRIPTION
Currently, if a reflink is matched (`[text][def]`) but no def is found, the reflink is outputted as a link but with no href.

This PR changes this so that if a def is not found for the reflink, the reflink is outputted as is (but parsed normally).