### PR TITLE
Add new block rule for htmlEntities

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "reddit-md-to-html",
-	"version": "0.1.63",
+	"version": "0.1.64",
 	"description": "A markdown to html converter for Reddit-flavored markdown",
 	"repository": {
 		"type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { brBackslash } from './rules/brBackslash.js';
 import { u } from './rules/u.js';
 import { redditlink } from './rules/redditlink.js';
 import { nonOrderedList } from './rules/nonOrderedList.js';
-import { htmlEntities } from './rules/htmlEntities.js';
+import { htmlEntities, htmlEntitiesBlock } from './rules/htmlEntities.js';
 import { link, linkBackwards, redditImageLink } from './rules/link.js';
 import { autolink } from './rules/autolink.js';
 import { url, redditImageUrl } from './rules/url.js';
@@ -32,6 +32,7 @@ const rules = Object.assign({}, SimpleMarkdown.defaultRules, {
 	redditlink,
 	nonOrderedList,
 	htmlEntities,
+	htmlEntitiesBlock,
 	paragraph,
 	heading,
 	lheading,

--- a/src/rules/htmlEntities.ts
+++ b/src/rules/htmlEntities.ts
@@ -2,6 +2,16 @@ import SimpleMarkdown from 'simple-markdown';
 import { SimpleMarkdownRule } from './ruleType.js';
 
 const htmlEntitiesRegex = /^&#?[^;&\s<>]+;/i;
+const htmlEntitiesRegexBlock = /^(&#?[^;&\s<>]+;)\n*/i;
+
+export const htmlEntitiesBlock: SimpleMarkdownRule = {
+	order: SimpleMarkdown.defaultRules.heading.order - 0.5,
+	match: SimpleMarkdown.blockRegex(htmlEntitiesRegexBlock),
+	parse: function (capture) {
+		return { type: 'paragraph', content: [{ content: capture[1], type: 'htmlEntities' }] };
+	},
+	html: null
+};
 
 export const htmlEntities: SimpleMarkdownRule = {
 	order: SimpleMarkdown.defaultRules.hr.order - 0.5,

--- a/tests/heading.test.ts
+++ b/tests/heading.test.ts
@@ -47,6 +47,15 @@ pub enum Error {
 		const htmlResult = converter('#');
 		expect(htmlResult).toBe('');
 	});
+
+	test('heading with htmlEntity before #', () => {
+		const text = `&nbsp;
+###[Event Overview](https://imgur.com/a/CUI6Y9f)`;
+		const htmlResult = converter(text);
+		expect(htmlResult).toBe(
+			'<p>&nbsp;</p><h3><a href="https://imgur.com/a/CUI6Y9f" rel="noopener nofollow ugc">Event Overview</a></h3>'
+		);
+	});
 });
 
 describe('lheading', () => {


### PR DESCRIPTION
Adds a new block rule for htmlEntities. 

This is needed since an htmlEntity can be on it's own line, and the inline version does not need to set the `state.inline` value correctly.